### PR TITLE
Task 7. Add Auth integration

### DIFF
--- a/src/app/admin/manage-products/manage-products.service.ts
+++ b/src/app/admin/manage-products/manage-products.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Injector } from '@angular/core';
 import { EMPTY, Observable } from 'rxjs';
 import { ApiService } from '../../core/api.service';
-import { switchMap } from 'rxjs/operators';
+import { catchError, switchMap } from 'rxjs/operators';
 
 @Injectable()
 export class ManageProductsService extends ApiService {
@@ -18,8 +18,8 @@ export class ManageProductsService extends ApiService {
     }
 
     return this.getPreSignedUrl(file.name).pipe(
-      switchMap((url) =>
-        this.http.put(url, file, {
+      switchMap((url: any) =>
+        this.http.put(url.message, file, {
           headers: {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             'Content-Type': 'text/csv',
@@ -31,11 +31,16 @@ export class ManageProductsService extends ApiService {
 
   private getPreSignedUrl(fileName: string): Observable<string> {
     const url = this.getUrl('import', 'import');
+    const authorizationToken = localStorage.getItem('authorization_token')!;
+    const headers: any = authorizationToken ? {
+      'Authorization': authorizationToken,
+    } : {};
 
     return this.http.get<string>(url, {
       params: {
         name: fileName,
       },
+      headers
     });
   }
 }

--- a/src/app/core/interceptors/error-print.interceptor.ts
+++ b/src/app/core/interceptors/error-print.interceptor.ts
@@ -19,11 +19,18 @@ export class ErrorPrintInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<unknown>> {
     return next.handle(request).pipe(
       tap({
-        error: () => {
+        error: error => {
           const url = new URL(request.url);
 
+          if (error.error instanceof ErrorEvent) {
+            return this.notificationService.showError(
+              `Request to "${url.pathname}" failed. Check the console for the details`,
+              0
+            );
+          }
+
           this.notificationService.showError(
-            `Request to "${url.pathname}" failed. Check the console for the details`,
+            `${error.status}: ${error.error.message}`,
             0
           );
         },

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,7 +9,7 @@ export const environment: Config = {
   apiEndpoints: {
     product: 'https://.execute-api.us-east-1.amazonaws.com/dev',
     order: 'https://.execute-api.us-east-1.amazonaws.com/dev',
-    import: 'https://.execute-api.us-east-1.amazonaws.com/dev',
+    import: 'https://88xgxr26h3.execute-api.us-east-1.amazonaws.com/dev',
     bff: 'https://qwoeu1qbla.execute-api.us-east-1.amazonaws.com/dev',
     cart: 'https://.execute-api.us-east-1.amazonaws.com/dev',
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,4 +10,13 @@ if (environment.production) {
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule)
+  .then(() => {
+    if (environment.production) {
+      return;
+    }
+    localStorage.setItem(
+      'authorization_token',
+      `${btoa('zomboy90:TEST_PASSWORD')}`
+    );
+  })
   .catch((err) => console.error(err));


### PR DESCRIPTION
# Task 7. Authorization

Done:

- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)
- [x] (+30) Client application should display alerts for the responses in 401 and 403 HTTP statuses.

Result: 100